### PR TITLE
Setting stereo of double bonds to IBond.Stereo.E_Z_BY_COORDINATES so …

### DIFF
--- a/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
+++ b/storage/ctab/src/main/java/org/openscience/cdk/io/MDLV3000Reader.java
@@ -529,6 +529,8 @@ public class MDLV3000Reader extends DefaultChemObjectReader {
                     if (order < 4){
 
                         bond.setOrder(BondManipulator.createBondOrder((double) order));
+                        if(order == 2)
+                            bond.setStereo(IBond.Stereo.E_Z_BY_COORDINATES);
                     } else if(order == 4) {
 
                         bond.setFlag(CDKConstants.SINGLE_OR_DOUBLE, true);


### PR DESCRIPTION
…that

the V3000 reader behaves the same as the V2000 reader